### PR TITLE
Replacing Distribute with Setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='Clockwork',


### PR DESCRIPTION
As mentioned on http://pythonhosted.org/distribute/, distribute is deprecated:

> Distribute is a deprecated fork of the Setuptools project.
> 
> Since the Setuptools 0.7 release, Setuptools and Distribute have merged and Distribute is no longer being maintained. All ongoing effort should reference the Setuptools project and the Setuptools documentation.

This fixes the `[..]/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_requires'` error.
