### PR TITLE
Remove the lxml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,12 @@
 ## Install
 
 The easiest way to install is through "pip":
-    
+
     pip install clockwork
 
 ## Requirements
 
 * Python 2.6+
-* [lxml][1] 
-
-For an easy life, we recommend installing lxml thorugh a package manager, e.g.:
-    
-    sudo apt-get install python-lxml    # Debian based
-    sudo yum install pyhton-lxml        # Red Hat based
 
 ## Usage
 
@@ -32,7 +26,7 @@ else:
     print (response.error_code)
     print (response.error_message)
 ```
-   
+
 ### Send multiple SMS messages
 
 Simply pass an array of sms objects to the send method. Instead of sending back a single sms response, an array of sms responses will be returned:
@@ -64,11 +58,11 @@ This wrapper supports a subset of the available clockwork API parameters for sen
 You create an `api` object with `api = clockwork.API(api_key,[optional_setting = value,..]`
 The `optional_setting` parameters allows you to set the following, which will be used for all messages sent through the `api` object:
 
-Parameter | Description 
---------- | -----------  
-from_name | Sets the [from name](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-from "from address") 
-concat | Sets the [concat](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-concat) setting 
-invalid_char_option | Sets the [InvalidCharOption](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-invalidcharaction) setting  
+Parameter | Description
+--------- | -----------
+from_name | Sets the [from name](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-from "from address")
+concat | Sets the [concat](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-concat) setting
+invalid_char_option | Sets the [InvalidCharOption](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-invalidcharaction) setting
 truncate | Sets the [truncate](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-truncate) setting
 
 So for example if I want all messages to use the from address 'bobby', I would do:
@@ -82,12 +76,12 @@ So for example if I want all messages to use the from address 'bobby', I would d
 You create an `sms` object with `sms = clockwork.SMS(to = 'xxx', message = 'xxx', [optional_setting = value,..]`
 
 In a similar pattern to the API parameters, the `optional_setting` parameters allows you to set the following additional parameters for an individual message:
- 
-Parameter | Description 
---------- | ----------- 
-client_id | Sets the [ClientId](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-clientid) setting 
-from_name | Sets the [from name](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-from "from address") 
-invalid_char_option | Sets the [InvalidCharOption](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-invalidcharaction) setting  
+
+Parameter | Description
+--------- | -----------
+client_id | Sets the [ClientId](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-clientid) setting
+from_name | Sets the [from name](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-from "from address")
+invalid_char_option | Sets the [InvalidCharOption](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-invalidcharaction) setting
 truncate | Sets the [truncate](http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/#param-truncate) setting
 
 Any parameters defined here will take precedence over the same one defined on the `api` object:
@@ -119,10 +113,9 @@ If you have any feedback on this wrapper drop us an email to [hello@clockworksms
 
 The project is hosted on GitHub at [http://www.github.com/mediaburst/clockwork-python][4].
 
-If you would like to contribute a bug fix or improvement please fork the project 
+If you would like to contribute a bug fix or improvement please fork the project
 and submit a pull request. Please add tests for your use case.
 
-[1]: http://lxml.de/
 [2]: http://www.clockworksms.com/doc/clever-stuff/xml-interface/send-sms/
 [3]: mailto:hello@clockworksms.com
 [4]: http://www.github.com/mediaburst/clockwork-python

--- a/clockwork/__init__.py
+++ b/clockwork/__init__.py
@@ -1,0 +1,2 @@
+from . clockwork import API, SMS
+from . clockwork_exceptions import ApiException, AuthException, GenericException, HttpException

--- a/clockwork/clockwork_exceptions.py
+++ b/clockwork/clockwork_exceptions.py
@@ -3,18 +3,21 @@
 class HttpException(Exception):
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
 
 class AuthException(Exception):
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
 
 class GenericException(Exception):
     def __init__(self, value):
         self.value = value
+
     def __str__(self):
         return repr(self.value)
 
@@ -22,5 +25,6 @@ class ApiException(Exception):
     def __init__(self, value, errNum):
         self.value = value
         self.errNum = errNum
+
     def __str__(self):
         return repr(self.value)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ setup(
     name='Clockwork',
     version='1.1.0',
     packages=['clockwork'],
-    install_requires=['lxml'],
     license='MIT',
     author='Mediaburst',
     author_email='hello@clockworksms.com',

--- a/tests/clockwork_tests.py
+++ b/tests/clockwork_tests.py
@@ -64,7 +64,7 @@ class ApiTests(unittest.TestCase):
         api = clockwork.API(self.api_key)
         sms1 = clockwork.SMS(to="441234567890", message="This is a test message 1")
         sms2 = clockwork.SMS(to="441234567890", message="")
-        response = api.send([sms1,sms2])
+        response = api.send([sms1, sms2])
 
         self.assertTrue(response[0].success)
         self.assertFalse(response[1].success)
@@ -77,12 +77,7 @@ class ApiTests(unittest.TestCase):
     def test_should_be_able_to_get_balance(self):
         api = clockwork.API(self.api_key)
         balance = api.get_balance()
-        self.assertEqual('PAYG',balance['account_type'])
+        self.assertEqual('PAYG', balance['account_type'])
 
 if __name__ == "__main__":
     unittest.main()
-
-
-
-
-


### PR DESCRIPTION
This pull request removes the dependency on the lxml module in favor of Python's build in xml module. The lxml module dependency unnecessarily complicates the installation process of the clockwork-python package making it more difficult to include in software distributions. This PR also adjusts white space to be more pep8 compliant.
